### PR TITLE
Accepts $Params like $foo_bar

### DIFF
--- a/src/Route.php
+++ b/src/Route.php
@@ -69,7 +69,7 @@ class Route {
 				}
 			}
 
-			$r = preg_replace('/:[a-z]+/i','.*',$this->_route);
+			$r = preg_replace('/:[a-z_]+/i','.*',$this->_route);
 			$r = preg_replace('/\//','\/',$r);
 
 			if (preg_match('/^'.$r.'$/'.($this->_caseSensitive ? '' : 'i'),$page)) {


### PR DESCRIPTION
Accepts variable names in $Params using _

Example:

$app->get('foo/:foo_bar',function($View, $Params) {
    $View->display('index', ['foo_bar' => $Params->foo_bar]);
});